### PR TITLE
Replace ifeval with tags

### DIFF
--- a/docs/00-preamble/00-introduction.adoc
+++ b/docs/00-preamble/00-introduction.adoc
@@ -1,10 +1,10 @@
-ifeval::["{language}" == "DE"]
+// tag::DE[]
 == Einführung: Allgemeines zum iSAQB Advanced Level
-endif::[]
+// end::DE[]
 
-ifeval::["{language}" == "EN"]
+// tag::EN[]
 == Introduction: General information about the iSAQB Advanced Level
-endif::[]
+// end::EN[]
 
 include::01-what-to-expect-of-this-module.adoc[{include_configuration}]
 

--- a/docs/00-preamble/copyright.adoc
+++ b/docs/00-preamble/copyright.adoc
@@ -3,8 +3,6 @@
 include::../config/_feedback.adoc[]
 // end::FEEDBACK[]
 
-[discrete]
-
 // tag::DE[]
 [.text-center]
 *© (Copyright), International Software Architecture Qualification Board e. V.

--- a/docs/01-basics/00-basics.adoc
+++ b/docs/01-basics/00-basics.adoc
@@ -2,13 +2,17 @@
 // (c) iSAQB e.V. (https://isaqb.org)
 // ====================================================
 
-ifeval::["{language}" == "DE"]
-== Grundlegendes
-endif::[]
+// tag::DE[]
 
-ifeval::["{language}" == "EN"]
+== Grundlegendes
+
+// end::DE[]
+
+// tag::EN[]
+
 == Basics
-endif::[]
+
+// end::EN[]
 
 include::01-curriculum-structure-and-chronological-breakdown.adoc[{include_configuration}]
 

--- a/docs/01-basics/01-curriculum-structure-and-chronological-breakdown.adoc
+++ b/docs/01-basics/01-curriculum-structure-and-chronological-breakdown.adoc
@@ -89,9 +89,15 @@ image:chronological_breakdown.png[pdfwidth=75%, role="text-center"]
 // tag::REMARK[]
 [IMPORTANT]
 ====
+
+// tag::DE[]
 Bitte sowohl die oben angegebene Tabelle als auch das beiliegende Excel-Dokument entsprechend anpassen und das Pie-Chart als "zeitaufteilung.png" nach `../images` exportieren
-- - -
+// end::DE[]
+
+
+// tag::EN[]
 Please adjust the table above as well as the excel document according to your curriculum and export the pie chart
 as "chronological_breakdown.png" to `../images`.
+// end::EN[]
 ====
 // end::REMARK[]

--- a/docs/02-introduction-to-isaqb/00-intro.adoc
+++ b/docs/02-introduction-to-isaqb/00-intro.adoc
@@ -2,13 +2,13 @@
 // (c) iSAQB e.V. (https://isaqb.org)
 // ====================================================
 
-ifeval::["{language}" == "DE"]
+// tag::DE[]
 == Einführung in das iSAQB-Zertifizierungsprogramm
-endif::[]
+// end::DE[]
 
-ifeval::["{language}" == "EN"]
-== Introduction to the iSAQB cerification program
-endif::[]
+// tag::EN[]
+== Introduction to the iSAQB certification program
+// end::EN[]
 
 include::01-intro-duration-terms.adoc[{include_configuration}]
 

--- a/docs/03-introducing-the-module/00-introducing-module.adoc
+++ b/docs/03-introducing-the-module/00-introducing-module.adoc
@@ -2,13 +2,13 @@
 // (c) iSAQB e.V. (https://isaqb.org)
 // ====================================================
 
-ifeval::["{language}" == "DE"]
+// tag::DE[]
 == Erste Lerneinheit
-endif::[]
+// end::DE[]
 
-ifeval::["{language}" == "EN"]
+// tag::EN[]
 == Lesson 1
-endif::[]
+// end::EN[]
 
 include::01-introducing-module-duration-terms.adoc[{include_configuration}]
 

--- a/docs/04-second-learning-unit/00-second-unit.adoc
+++ b/docs/04-second-learning-unit/00-second-unit.adoc
@@ -3,13 +3,13 @@
 // ====================================================
 
 
-ifeval::["{language}" == "DE"]
+// tag::DE[]
 == Zweite Lerneinheit
-endif::[]
+// end::DE[]
 
-ifeval::["{language}" == "EN"]
+// tag::EN[]
 == Lesson 2
-endif::[]
+// end::EN[]
 
 include::01-second-unit-duration-terms.adoc[{include_configuration}]
 

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -10,13 +10,13 @@ include::../config/_feedback.adoc[]
 [bibliography]
 == {references}
 
-ifeval::["{language}" == "DE"]
+// tag::DE[]
 Dieser Abschnitt enthält Quellenangaben, die ganz oder teilweise im Curriculum referenziert werden.
-endif::[]
+// end::DE[]
 
-ifeval::["{language}" == "EN"]
+// tag::EN[]
 This section contains references that are cited in the curriculum.
-endif::[]
+// end::EN[]
 
 B +
 [[[Bachmann 2000]]] Bachmann, F., L. Bass, et al.: Software Architecture Documentation in Practice. Software Engineering Institute, CMU/SEI-2000-SR-004.

--- a/docs/advanced-curriculum.adoc
+++ b/docs/advanced-curriculum.adoc
@@ -38,30 +38,24 @@ toc::[]
 
 <<<
 :sectnums!:
-include::00-preamble/00-introduction.adoc[]
+include::00-preamble/00-introduction.adoc[include_configuration]
 
 <<<
 :sectnums:
-// don't use {include_configuration} here, otherwise nothing gets included
-include::01-basics/00-basics.adoc[]
+include::01-basics/00-basics.adoc[include_configuration]
 
 <<<
-// don't use {include_configuration} here, otherwise nothing gets included
-include::02-introduction-to-isaqb/00-intro.adoc[]
+include::02-introduction-to-isaqb/00-intro.adoc[include_configuration]
 
 
 <<<
-// don't use {include_configuration} here, otherwise nothing gets included
-include::03-introducing-the-module/00-introducing-module.adoc[]
+include::03-introducing-the-module/00-introducing-module.adoc[include_configuration]
 
 <<<
-// don't use {include_configuration} here, otherwise nothing gets included
-include::04-second-learning-unit/00-second-unit.adoc[]
-
+include::04-second-learning-unit/00-second-unit.adoc[include_configuration]
 
 <<<
-// don't use {include_configuration} here, otherwise nothing gets included
-include::98-examples/00-examples.adoc[]
+include::98-examples/00-examples.adoc[include_configuration]
 
 <<<
-include::99-references/00-references.adoc[]
+include::99-references/00-references.adoc[include_configuration]

--- a/docs/advanced-curriculum.adoc
+++ b/docs/advanced-curriculum.adoc
@@ -38,24 +38,24 @@ toc::[]
 
 <<<
 :sectnums!:
-include::00-preamble/00-introduction.adoc[include_configuration]
+include::00-preamble/00-introduction.adoc[{include_configuration}]
 
 <<<
 :sectnums:
-include::01-basics/00-basics.adoc[include_configuration]
+include::01-basics/00-basics.adoc[{include_configuration}]
 
 <<<
-include::02-introduction-to-isaqb/00-intro.adoc[include_configuration]
+include::02-introduction-to-isaqb/00-intro.adoc[{include_configuration}]
 
 
 <<<
-include::03-introducing-the-module/00-introducing-module.adoc[include_configuration]
+include::03-introducing-the-module/00-introducing-module.adoc[{include_configuration}]
 
 <<<
-include::04-second-learning-unit/00-second-unit.adoc[include_configuration]
+include::04-second-learning-unit/00-second-unit.adoc[{include_configuration}]
 
 <<<
-include::98-examples/00-examples.adoc[include_configuration]
+include::98-examples/00-examples.adoc[{include_configuration}]
 
 <<<
-include::99-references/00-references.adoc[include_configuration]
+include::99-references/00-references.adoc[{include_configuration}]

--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -25,8 +25,8 @@ endif::withFeedback[]
 // currently only DE and EN are supported
 :language: DE
 
-// ":include_configuration:" always consists of the language, eventually
-// followed by ";REMARK".
+// ":include_configuration:" always consists of the language, optionally
+// followed by ";REMARK" or ";FEEDBACK".
 // additional markers might be configured here!
 :include_configuration: tags=**;{language}{remarks}{feedback};!*
 

--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -28,7 +28,7 @@ endif::withFeedback[]
 // ":include_configuration:" always consists of the language, eventually
 // followed by ";REMARK".
 // additional markers might be configured here!
-:include_configuration: tags={language}{remarks}{feedback}
+:include_configuration: tags=**;{language}{remarks}{feedback};!*
 
 :curriculum-short: MODULKUERZEL
 


### PR DESCRIPTION
With the changes to `setup.adoc`, it is now possible to use `{include_configuration}` on every level. This allows us to use the language tags even for chapter headings.

Closes #3 .