### PR TITLE
Some suggestions while fiddling with flex-curriculum

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,7 +150,11 @@ For that purpose we define a variable named `include_configuration` in the file 
 
 ==== Structure File Example
 
-File `advanced-curriculum.adoc` (excerpts):
+In theory, you can just use the `docs/advanced-curriculum.adoc` as is and just
+edit the section documents in the subdirectories. If you want to create your own file,
+we recommend to stick with the following:
+
+From `docs/advanced-curriculum.adoc` (excerpts):
 
 [source,asciidoc]
 ----
@@ -173,10 +177,10 @@ include::00-preamble/00-introduction.adoc[] // //<6>
 
 ----
 
-1. We propose to put the asciidoc configuration in this special file (`setup.adoc`).
+1. We propose to put the asciidoc configuration in this special file (`docs/config/setup.adoc`).
 2. You can set a version, but it may be overridden in the build process.
 3. You can turn section numbering on and off (here: off).
-4. This includes parts of the copyright.adoc file.
+4. This includes parts of the `docs/00-preamble/copyright.adoc` file.
 5. The `<<<` will create a pagebreak in pdf files.
 6. Include the whole file 00-introduction.adoc.
 
@@ -189,7 +193,8 @@ TBD.
 
 Prerequisite: You need a Java Runtime(tm) installed.
 
-You build the output documents with gradle. That will produce both pdf and html output in German (DE) _and_ English (EN), unless you modify the configuration. 
+You build the output documents with gradle.
+That will produce both pdf and html output in German (DE) _and_ English (EN), unless you modify the configuration.
 
 In case you want to change that, adjust the following part of `build.gradle`:
 
@@ -202,7 +207,7 @@ task buildDocs {
 }
 ----
 
-In the task "renderNoRemarksDE", certain attributes (aka variables) are defined that configure the corresponding output. 
+In the task "renderNoRemarksDE", certain attributes (aka variables) are defined that configure the corresponding output.
 
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,7 @@ Create an issue, a merge- or pull-request
 git clone git@github.com/username/repository.git --recursive
 ----
 --
-2. Build it with gradle.
+2. Build it with gradle via `./gradle buildDocs`.
 3. Look into the file `build.gradle` to see what attributes you may configure. Watch for:
 ** the `language` attribute, either `DE` (German) or `EN` (English);
 ** the output formats called `backends` (pdf and/or html5);

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,11 @@ ext {
   currentDate = new Date().format("d. MMM yyyy")
   project.version = "0.1.0 DRAFT ($currentDate)"
   curriculumBaseName = "advanced-curriculum"
+  curriculumFileName = "advanced-curriculum"
   addSuffixToCurriculum = { suffix ->
     for (extension in ["html", "pdf"]) {
-      File source = new File("${buildDir}/${curriculumBaseName}.${extension}")
-      File target = new File("${buildDir}/${curriculumBaseName}${suffix}.${extension}")
+      File source = new File("${buildDir}/${curriculumFileName}.${extension}")
+      File target = new File("${buildDir}/${curriculumFileName}${suffix}.${extension}")
 
       source.renameTo(target)
     }
@@ -30,11 +31,11 @@ ext {
 
 class RenderCurriculumTask extends AsciidoctorTask {
   @Inject
-  RenderCurriculumTask(String curriculumBaseName, String currentDate, String language, boolean withRemarks) {
+  RenderCurriculumTask(String curriculumBaseName, String curriculumFileName, String currentDate, String language, boolean withRemarks) {
     sourceDir = new File("./docs/")
     sources {
       include "index.adoc"
-      include "${curriculumBaseName}.adoc"
+      include "${curriculumFileName}.adoc"
     }
     outputDir = new File("./build/")
     separateOutputDirs = false
@@ -42,6 +43,7 @@ class RenderCurriculumTask extends AsciidoctorTask {
     attributes = [
       'icons'            : 'font',
       'document-version' : "${project.version}",
+      'curriculumBaseName': curriculumBaseName,
       'currentDate'      : currentDate,
       'language'         : language,
       'withRemarks'      : withRemarks,
@@ -60,28 +62,28 @@ task buildDocs {
 }
 
 task renderNoRemarksDE(type: RenderCurriculumTask,
-    constructorArgs: [curriculumBaseName, currentDate, "DE", false]) {
+    constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "DE", false]) {
   doLast {
     addSuffixToCurriculum("_de")
   }
 }
 
 task renderWithRemarksDE(type: RenderCurriculumTask,
-     constructorArgs: [curriculumBaseName, currentDate, "DE", true]) {
+     constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "DE", true]) {
    doLast {
      addSuffixToCurriculum("_remarks_de")
    }
  }
 
 task renderNoRemarksEN(type: RenderCurriculumTask,
-    constructorArgs: [curriculumBaseName, currentDate, "EN", false]) {
+    constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "EN", false]) {
   doLast {
     addSuffixToCurriculum("_en")
   }
 }
 
 task renderWithRemarksEN(type: RenderCurriculumTask,
-     constructorArgs: [curriculumBaseName, currentDate, "EN", true]) {
+     constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "EN", true]) {
    doLast {
      addSuffixToCurriculum("_remarks_en")
    }

--- a/docs/00-preamble/00-introduction.adoc
+++ b/docs/00-preamble/00-introduction.adoc
@@ -6,8 +6,6 @@
 == Introduction: General information about the iSAQB Advanced Level
 // end::EN[]
 
-include::01-what-to-expect-of-this-module.adoc[{include_configuration}]
-
 include::02-what-to-expect-of-an-advanced-level-module.adoc[{include_configuration}]
 
 include::03-advanced-level-knowledge.adoc[{include_configuration}]

--- a/docs/00-preamble/04-prerequisites.adoc
+++ b/docs/00-preamble/04-prerequisites.adoc
@@ -5,7 +5,7 @@ include::../config/_feedback.adoc[]
 
 // tag::DE[]
 === Voraussetzungen zur CPSA-A-Zertifizierung
-* erfolgreiche Ausbildung und Zertifizierung zum CPSA-F (Certified Professional for Software Architecture, Foundation Level)
+* erfolgreiche Ausbildung und Zertifizierung zum Certified Professional for Software Architecture, Foundation Level^®^ (CPSA-F)
 * mindestens drei Jahre Vollzeit-Berufserfahrung in der IT-Branche; dabei Mitarbeit an Entwurf und Entwicklung von mindestens zwei unterschiedlichen IT-Systemen
 ** Ausnahmen sind auf Antrag zulässig (etwa: Mitarbeit in Open-Source-Projekten)
 * Aus- und Weiterbildung im Rahmen von iSAQB-Advanced-Level-Schulungen im Umfang von mindestens 70 Credit Points aus mindestens zwei unterschiedlichen Kompetenzbereichen
@@ -16,7 +16,7 @@ include::../config/_feedback.adoc[]
 
 // tag::EN[]
 === Requirements for the CPSA-A certification
-* successful training and graduation of CPSA-F (Certified Professional for Software Architecture, Foundation Level)
+* successful training and graduation of Certified Professional for Software Architecture, Foundation Level^®^ (CPSA-F)
 * at least three years industrial, full-time experience in the IT sector; including collaboration on design and development of at least two different IT systems
 ** exceptions may be granted (for example: contributions to open source projects)
 * participation at iSAQB Advanced Level trainings worth at least 70 credit points from two different areas of competence

--- a/docs/01-basics/02-timing-didactics-and-more.adoc
+++ b/docs/01-basics/02-timing-didactics-and-more.adoc
@@ -6,10 +6,10 @@ include::../config/_feedback.adoc[]
 // tag::REMARK[]
 [IMPORTANT]
 ====
-Bitte die Anzahl der Tage sowie der erreichbaren Punkte oben bei den **?** einsetzen.
+Bitte die **?** durch die Anzahl der Tage sowie die erreichbaren Punkte ersetzen.
 ====
 // end::REMARK[]
-:recommended-duration: **?**
+:recommended-duration-in-days: **?**
 :methodical-credits: **?**
 :technical-credits: **?**
 :communicative-credits: **?**
@@ -18,7 +18,7 @@ Bitte die Anzahl der Tage sowie der erreichbaren Punkte oben bei den **?** einse
 === Dauer, Didaktik und weitere Details
 
 Die unten genannten Zeiten sind Empfehlungen. Die Dauer einer Schulung zum Modul {curriculum-short}
-sollte mindestens {recommended-duration} Tage betragen, kann aber länger sein.
+sollte mindestens {recommended-duration-in-days} Tage betragen, kann aber länger sein.
 Anbieter können sich durch Dauer, Didaktik, Art und Aufbau der Übungen sowie der detaillierten Kursgliederung voneinander unterscheiden.
 Insbesondere die Art der Beispiele und Übungen lässt der Lehrplan komplett offen.
 
@@ -34,7 +34,7 @@ Kommunikative Kompetenz:	{communicative-credits} Punkte
 === Duration, didactics, and further details
 
 The durations mentioned below are recommendations.
-A course for the {curriculum-short} should last at least {recommended-duration} days.
+A course for the {curriculum-short} should last at least {recommended-duration-in-days} days.
 Provides may vary length, didactics, type and structure of exercises, and structure of the course.
 In particular, examples and exercises are left unspecified in this curriculum.
 

--- a/docs/01-basics/02-timing-didactics-and-more.adoc
+++ b/docs/01-basics/02-timing-didactics-and-more.adoc
@@ -3,16 +3,30 @@
 include::../config/_feedback.adoc[]
 // end::FEEDBACK[]
 
+// tag::REMARK[]
+[IMPORTANT]
+====
+Bitte die Anzahl der Tage sowie der erreichbaren Punkte oben bei den **?** einsetzen.
+====
+// end::REMARK[]
+:recommended-duration: **?**
+:methodical-credits: **?**
+:technical-credits: **?**
+:communicative-credits: **?**
+
 // tag::DE[]
 === Dauer, Didaktik und weitere Details
 
-Die unten genannten Zeiten sind Empfehlungen. Die Dauer einer Schulung zum Modul {curriculum-short} sollte mindestens **?** Tage betragen, kann aber länger sein. Anbieter können sich durch Dauer, Didaktik, Art und Aufbau der Übungen sowie der detaillierten Kursgliederung voneinander unterscheiden. Insbesondere die Art der Beispiele und Übungen lässt der Lehrplan komplett offen.
+Die unten genannten Zeiten sind Empfehlungen. Die Dauer einer Schulung zum Modul {curriculum-short}
+sollte mindestens {recommended-duration} Tage betragen, kann aber länger sein.
+Anbieter können sich durch Dauer, Didaktik, Art und Aufbau der Übungen sowie der detaillierten Kursgliederung voneinander unterscheiden.
+Insbesondere die Art der Beispiele und Übungen lässt der Lehrplan komplett offen.
 
 Lizenzierte Schulungen zu {curriculum-short} tragen zur Zulassung zur abschließenden Advanced-Level-Zertifizierungsprüfung folgende Credit Points) bei:
 
-Methodische Kompetenz:	**?** Punkte +
-Technische Kompetenz:		**?** Punkte +
-Kommunikative Kompetenz:	**?** Punkte
+Methodische Kompetenz:	{methodical-credits} Punkte +
+Technische Kompetenz:		{technical-credits} Punkte +
+Kommunikative Kompetenz:	{communicative-credits} Punkte
 
 // end::DE[]
 
@@ -20,20 +34,13 @@ Kommunikative Kompetenz:	**?** Punkte
 === Duration, didactics, and further details
 
 The durations mentioned below are recommendations.
-A course for the {curriculum-short} should last at least **?** days.
+A course for the {curriculum-short} should last at least {recommended-duration} days.
 Provides may vary length, didactics, type and structure of exercises, and structure of the course.
 In particular, examples and exercises are left unspecified in this curriculum.
 
 Licensed courses for {curriculum-short} contribute the following credit points to the Advanced Level graduation:
 
-Methodical Competence:	**?** Points +
-Technical Competence:		**?** Points +
-Communicative Competence:	**?** Points
+Methodical Competence:	{methodical-credits} Points +
+Technical Competence:		{technical-credits} Points +
+Communicative Competence:	{communicative-credits} Points
 // end::EN[]
-
-// tag::REMARK[]
-[IMPORTANT]
-====
-Bitte die Anzahl der Tage sowie der erreichbaren Punkte oben bei den **?** einsetzen.
-====
-// end::REMARK[]

--- a/docs/01-basics/02-timing-didactics-and-more.adoc
+++ b/docs/01-basics/02-timing-didactics-and-more.adoc
@@ -24,9 +24,12 @@ Insbesondere die Art der Beispiele und Übungen lässt der Lehrplan komplett off
 
 Lizenzierte Schulungen zu {curriculum-short} tragen zur Zulassung zur abschließenden Advanced-Level-Zertifizierungsprüfung folgende Credit Points) bei:
 
-Methodische Kompetenz:	{methodical-credits} Punkte +
-Technische Kompetenz:		{technical-credits} Punkte +
-Kommunikative Kompetenz:	{communicative-credits} Punkte
+[stripes=none, frame=none, grid=rows]
+|===
+| Methodische Kompetenz: | {methodical-credits} Punkte
+| Technische Kompetenz: | {technical-credits} Punkte
+| Kommunikative Kompetenz: | {communicative-credits} Punkte
+|===
 
 // end::DE[]
 
@@ -40,7 +43,11 @@ In particular, examples and exercises are left unspecified in this curriculum.
 
 Licensed courses for {curriculum-short} contribute the following credit points to the Advanced Level graduation:
 
-Methodical Competence:	{methodical-credits} Points +
-Technical Competence:		{technical-credits} Points +
-Communicative Competence:	{communicative-credits} Points
+[stripes=none, frame=none, grid=rows]
+|===
+| Methodical Competence: | {methodical-credits} Points
+| Technical Competence: | {technical-credits} Points
+| Communicative Competence: | {communicative-credits} Points
+|===
+
 // end::EN[]

--- a/docs/advanced-curriculum.adoc
+++ b/docs/advanced-curriculum.adoc
@@ -41,6 +41,10 @@ toc::[]
 include::00-preamble/00-introduction.adoc[{include_configuration}]
 
 <<<
+:sectnums!:
+include::what-to-expect-of-this-module.adoc[{include_configuration}]
+
+<<<
 :sectnums:
 include::01-basics/00-basics.adoc[{include_configuration}]
 

--- a/docs/advanced-curriculum.adoc
+++ b/docs/advanced-curriculum.adoc
@@ -34,11 +34,11 @@ endif::[]
 include::00-preamble/copyright.adoc[{include_configuration}]
 
 <<<
-toc::[]
-
-<<<
 :sectnums!:
 include::00-preamble/00-introduction.adoc[{include_configuration}]
+
+<<<
+toc::[]
 
 <<<
 :sectnums:

--- a/docs/advanced-curriculum.adoc
+++ b/docs/advanced-curriculum.adoc
@@ -3,23 +3,23 @@
 include::config/setup.adoc[]
 
 ifeval::["{language}" == "DE"]
-= Curriculum fürpass:q[<br><br>]CPSA Certified Professional forpass:q[<br>]Software Architecture^®^pass:q[<br>]- Advanced Level -: pass:q[<br><br>]Modul:pass:q[<br>]{curriculum-short}pass:q[<br><br>]{curriculum-name}
+= Curriculum fürpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^®^pass:q[<br>]- Advanced Level - pass:q[<br><br>]Modul:pass:q[<br>]{curriculum-short}pass:q[<br><br>]{curriculum-name}
 :toc: left
 endif::[]
 
 ifeval::["{language}" == "EN"]
-= Curriculum forpass:q[<br><br>]CPSA Certified Professional forpass:q[<br>]Software Architecture^®^pass:q[<br>]- Advanced Level -: pass:q[<br><br>]Module:pass:q[<br>]{curriculum-short}pass:q[<br><br>]{curriculum-name}
+= Curriculum forpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^®^pass:q[<br>]- Advanced Level - pass:q[<br><br>]Module:pass:q[<br>]{curriculum-short}pass:q[<br><br>]{curriculum-name}
 :toc: left
 endif::[]
 
-// document-version should usually be overwritten by the build process,
+// document-version fallback, should usually be overwritten by the build process,
 // e.g. build.gradle
 :document-version: 2.0-DRAFT 2019
 
 // this is the base URL for the "improve this doc" links that directly link
 // to the source files in your repository; change this accordingly
-:project-repository-docs-edit-link: https://github.com/isaqb-org/advanced-template/blob/master/docs/
-:project-report-issue-link: https://github.com/isaqb-org/advanced-template/issues/new?title=&body=%0A%0A%5BEnter%20feedback%20here%5D%0A%0A%0A---%0A%23page:
+:project-repository-docs-edit-link: https://github.com/isaqb-org/{curriculumBaseName}/blob/master/docs/
+:project-report-issue-link: https://github.com/isaqb-org/{curriculumBaseName}/issues/new?title=&body=%0A%0A%5BEnter%20feedback%20here%5D%0A%0A%0A---%0A%23page:
 
 // define terms for toc, learning-goals
 include::config/i18n-definitions.adoc[tags={language}]

--- a/docs/advanced-curriculum.adoc
+++ b/docs/advanced-curriculum.adoc
@@ -34,11 +34,11 @@ endif::[]
 include::00-preamble/copyright.adoc[{include_configuration}]
 
 <<<
-:sectnums!:
-include::00-preamble/00-introduction.adoc[{include_configuration}]
+toc::[]
 
 <<<
-toc::[]
+:sectnums!:
+include::00-preamble/00-introduction.adoc[{include_configuration}]
 
 <<<
 :sectnums:

--- a/docs/what-to-expect-of-this-module.adoc
+++ b/docs/what-to-expect-of-this-module.adoc
@@ -1,10 +1,20 @@
 // tag::FEEDBACK[]
-:filename: 00-preamble/01-what-to-expect-of-this-module.adoc
-include::../config/_feedback.adoc[]
+:filename: what-to-expect-of-this-module.adoc
+include::config/_feedback.adoc[]
 // end::FEEDBACK[]
+
+// tag::REMARK[]
+[IMPORTANT]
+====
+Bitte diese Datei mit Ueberschrift 3. Ordnung beginnen, damit das Kapitel in
+der Struktur unterhalb von "00-preamble/introduction" eingeordnet wird.
+====
+// end::REMARK[]
+
 
 // tag::DE[]
 === Was vermittelt das Modul "{curriculum-short}"?
+
 Das Modul präsentiert den Teilnehmerinnen und Teilnehmern {curriculum-name} als …
 Am Ende des Moduls kennen die Teilnehmerinnen und Teilnehmer … und können …
 // end::DE[]


### PR DESCRIPTION
I made some adjustments while trying to get up to speed with flex-curriculum. I was uncertain whether I was supposed to use the `advanced-curriculum.adoc` file or you want curriculum maintainers to create e.g. `flex-curriculum.adoc` instead. The template is now prepared for both. ;)

I e.g. replaced the hardcoded links to https://github.com/isaqb-org/advanced-template/ with newly introduced variables and used these vars also in other places where applicable. Review welcome

NOTE: The PDF cover sheet needs to be refined as the text overlaps with the logo. I opened issue #9 for it. Maybe we can have a look at it together on Thursday.