### PR TITLE
Upgrade dependency of asciidoctorj-pdf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16"
+    classpath "org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.17"
   }
 }
 plugins {


### PR DESCRIPTION
This will allow us to use a new feature, which enables header and footer
on the front page or the TOC page.

This will enable https://github.com/isaqb-org/pdf-theme/pull/6.