### PR TITLE
Fix date formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 advanced-template.iml
 .settings/org.eclipse.buildship.core.prefs
 .project
+learning-objectives.adoc

--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ class RenderCurriculumTask extends AsciidoctorTask {
 }
 
 task buildDocs {
-	group 'Documentation'
-	description 'Grouping task for generating all languages in several formats'
+  group 'Documentation'
+  description 'Grouping task for generating all languages in several formats'
   dependsOn "includeLearningObjectives", "renderNoRemarksDE", "renderNoRemarksEN", "renderWithRemarksDE", "renderWithRemarksEN"
 }
 
@@ -80,10 +80,10 @@ task renderNoRemarksDE(type: RenderCurriculumTask,
 
 task renderWithRemarksDE(type: RenderCurriculumTask,
      constructorArgs: [curriculumBaseName, curriculumFileName, germanDate, "DE", true]) {
-   doLast {
-     addSuffixToCurriculum("_remarks_de")
-   }
- }
+  doLast {
+    addSuffixToCurriculum("_remarks_de")
+  }
+}
 
 task renderNoRemarksEN(type: RenderCurriculumTask,
     constructorArgs: [curriculumBaseName, curriculumFileName, englishDate, "EN", false]) {
@@ -94,12 +94,11 @@ task renderNoRemarksEN(type: RenderCurriculumTask,
 
 task renderWithRemarksEN(type: RenderCurriculumTask,
      constructorArgs: [curriculumBaseName, curriculumFileName, englishDate, "EN", true]) {
-   doLast {
-     addSuffixToCurriculum("_remarks_en")
-   }
- }
+  doLast {
+    addSuffixToCurriculum("_remarks_en")
+  }
+}
 
- apply from: 'scripts/includeLearningObjectives.gradle'
-
+apply from: 'scripts/includeLearningObjectives.gradle'
 
 defaultTasks "buildDocs"

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 ext {
   today = new Date()
-  englishDate = new SimpleDateFormat("MMM d, yyyy", Locale.US).format(today)
+  englishDate = new SimpleDateFormat("MMMM d, yyyy", Locale.US).format(today)
   germanDate = new SimpleDateFormat("d. MMMM yyy", Locale.GERMANY).format(today)
 
   project.version = project.file("./document.version").text

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import org.asciidoctor.gradle.AsciidoctorTask
 import javax.inject.Inject
+import java.text.SimpleDateFormat
 
 buildscript {
   repositories {
@@ -15,7 +16,10 @@ plugins {
 }
 
 ext {
-  currentDate = new Date().format("d. MMM yyyy")
+  today = new Date()
+  englishDate = new SimpleDateFormat("MMM d, yyyy", Locale.US).format(today)
+  germanDate = new SimpleDateFormat("d. MMMM yyy", Locale.GERMANY).format(today)
+
   project.version = project.file("./document.version").text
   curriculumBaseName = "advanced-curriculum"
   curriculumFileName = "advanced-curriculum"
@@ -68,28 +72,28 @@ task buildDocs {
 }
 
 task renderNoRemarksDE(type: RenderCurriculumTask,
-    constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "DE", false]) {
+    constructorArgs: [curriculumBaseName, curriculumFileName, germanDate, "DE", false]) {
   doLast {
     addSuffixToCurriculum("_de")
   }
 }
 
 task renderWithRemarksDE(type: RenderCurriculumTask,
-     constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "DE", true]) {
+     constructorArgs: [curriculumBaseName, curriculumFileName, germanDate, "DE", true]) {
    doLast {
      addSuffixToCurriculum("_remarks_de")
    }
  }
 
 task renderNoRemarksEN(type: RenderCurriculumTask,
-    constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "EN", false]) {
+    constructorArgs: [curriculumBaseName, curriculumFileName, englishDate, "EN", false]) {
   doLast {
     addSuffixToCurriculum("_en")
   }
 }
 
 task renderWithRemarksEN(type: RenderCurriculumTask,
-     constructorArgs: [curriculumBaseName, curriculumFileName, currentDate, "EN", true]) {
+     constructorArgs: [curriculumBaseName, curriculumFileName, englishDate, "EN", true]) {
    doLast {
      addSuffixToCurriculum("_remarks_en")
    }


### PR DESCRIPTION
We now use SimpleDateFormat, which allows us to provide locales to the
formatting process. Thus, we can create separate date formats for each
desired language. Currently, US English and German layout is supported.


Fix #38 .