### PR TITLE
Change style of references

### DIFF
--- a/docs/01-module-block-1/references.adoc
+++ b/docs/01-module-block-1/references.adoc
@@ -1,7 +1,6 @@
 === {references}
 
-- <<starke>>
-- <<bass>>
+<<bass>>, <<bachmann>>, <<kruchten>>, <<starke>>
 
 
 

--- a/docs/02-module-block-2/references.adoc
+++ b/docs/02-module-block-2/references.adoc
@@ -1,7 +1,6 @@
 === {references}
 
-- <<bass>>
-- <<clements>>
+<<bass>>, <<clements>>
 
 // tag::REMARK[]
 [NOTE]

--- a/docs/03-module-block-3/references.adoc
+++ b/docs/03-module-block-3/references.adoc
@@ -1,7 +1,6 @@
 === {references}
 
-- <<hargis>>
-- <<starke>>
+<<hargis>>, <<starke>>
 
 
 // tag::REMARK[]

--- a/docs/04-module-block-4/references.adoc
+++ b/docs/04-module-block-4/references.adoc
@@ -1,6 +1,6 @@
 === {references}
 
-- <<kruchten>>
+<<kruchten>>
 
 
 

--- a/docs/05-module-block-5/references.adoc
+++ b/docs/05-module-block-5/references.adoc
@@ -1,6 +1,6 @@
 === {references}
 
-- <<starke>>
+<<starke>>
 
 // tag::REMARK[]
 [NOTE]

--- a/docs/98-examples/references.adoc
+++ b/docs/98-examples/references.adoc
@@ -1,7 +1,6 @@
 === {references}
 
-- <<bachmann>>
-- <<kruchten>>
+<<bachmann>>, <<kruchten>>
 
 
 // tag::REMARK[]


### PR DESCRIPTION
Instead of a bullet list we simply list the references comma-separated.
This reduces the PDF size remarkably if there are 5 or more references
per chapter.

close #67