### PR TITLE
Move all output to dev null

### DIFF
--- a/.github/workflows/build_releasecandidate.yml
+++ b/.github/workflows/build_releasecandidate.yml
@@ -52,7 +52,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         rm -rf ./build/tmp
-        cp ./docs-ext/curriculum-*.pdf ./build
+        cp ./docs-ext/curriculum-*.pdf ./build 2>/dev/null || :
         zip -r release.zip ./build
     - name: Upload Release Files
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This will not break the build for release candidates if there are no PDF files to copy. 

Close #82 