### PR TITLE
Optimise Releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# exclude .gitignore, CI config and similar from the generated tarball
+.git*           export-ignore

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -13,33 +13,18 @@ The Advanced Level Template Curriculum is currently maintained and published in 
 Maintainers and volunteer reviewers collaborate on GitHub to improve the curriculum.
 
 |===
-| Version | Comments | HTML | PDF
+| Version | HTML | PDF
 
 | German
-|
 | link:{curriculumFileName}-de.html[HTML]
 | link:{curriculumFileName}-de.pdf[PDF]
 
 | English
-|
 | link:{curriculumFileName}-en.html[HTML]
 | link:{curriculumFileName}-en.pdf[PDF]
 
 | Español
 |
-|
 | link:{curriculumFileName}-es.pdf[PDF]
-
-
-
-| German
-| ✔️
-| link:{curriculumFileName}-remarks-de.html[HTML]
-| link:{curriculumFileName}-remarks-de.pdf[PDF]
-
-| English
-| ✔️
-| link:{curriculumFileName}-remarks-en.html[HTML]
-| link:{curriculumFileName}-remarks-en.pdf[PDF]
 
 |===


### PR DESCRIPTION
- Links to Remark files have been removed as the files are not generated anymore
- Source archives of releases do not contain any `.git*` files/folders anymore. This is achieved via `.gitattributes`

Nota Bene: We **cannot** remove source archives from releases. They are simply links that trigger a `git archive` call.


close #94 