### PR TITLE
Fix translation of TOC

### DIFF
--- a/docs/config/i18n-definitions.adoc
+++ b/docs/config/i18n-definitions.adoc
@@ -1,7 +1,6 @@
 // tag::DE[]
 :lang: DE
 :basics: Grundlegendes
-:toc-title: Inhaltsverzeichnis
 :learning-goals: Lernziele
 :references: Referenzen
 :examples: Beispiele
@@ -10,7 +9,6 @@
 // tag::EN[]
 :lang: EN
 :basics: Essentials
-:toc-title: Table of Contents
 :learning-goals: Learning Goals
 :references: References
 :examples: Examples

--- a/docs/curriculum-template.adoc
+++ b/docs/curriculum-template.adoc
@@ -4,6 +4,7 @@ include::config/setup.adoc[]
 
 ifeval::["{language}" == "DE"]
 = Curriculum fürpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^(R)^pass:q[<br>]_Advanced Level_: pass:q[<br>] Modulpass:q[<br>]{curriculum-short}pass:q[<br><br>]{curriculum-name}
+:toc-title: Inhaltsverzeichnis
 :toc: left
 endif::[]
 


### PR DESCRIPTION
toc-title has to be set directly beneath the very first heading.
Otherwise, it is ignored.
We can remove it from i18n-definitions.adoc

close #107 