### PR TITLE
Replace gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import java.text.SimpleDateFormat
-import java.util.*
 
 plugins {
     id "java"
@@ -10,6 +9,9 @@ def group = "org.isaqb"
 def releaseVersion = System.getenv("RELEASE_VERSION")
 def localVersion = "LocalBuild"
 project.version = releaseVersion == null ? localVersion : releaseVersion
+def curriculumFileName = "curriculum-template"
+def versionDate = new SimpleDateFormat("yyyyMMdd").format(new Date())
+def languages = ["DE", "EN"]
 
 repositories {
     mavenCentral()
@@ -17,12 +19,8 @@ repositories {
 
 dependencies {
     implementation("org.asciidoctor:asciidoctorj:2.5.10")
-    implementation("org.asciidoctor:asciidoctorj-pdf:2.3.7")
+    implementation("org.asciidoctor:asciidoctorj-pdf:2.3.9")
 }
-
-def curriculumFileName = "curriculum-template"
-def versionDate = new SimpleDateFormat("yyyyMMdd").format(new Date())
-def languages = ["DE", "EN"]
 
 application {
     mainClass.set("org.isaqb.asciidoc.Main")
@@ -37,10 +35,9 @@ application {
 
 apply from: 'scripts/includeLearningObjectives.gradle'
 
-task buildDocs (
-    description: 'Grouping task for generating all languages in several formats',
-    group: 'documentation'
-) {
+tasks.register('buildDocs') {
+    description = 'Grouping task for generating all languages in several formats'
+    group = 'documentation'
     dependsOn "includeLearningObjectives", "run"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,9 @@ plugins {
 }
 
 def group = "org.isaqb"
-def version = "1.0-SNAPSHOT"
+def releaseVersion = System.getenv("RELEASE_VERSION")
+def localVersion = "LocalBuild"
+project.version = releaseVersion == null ? localVersion : releaseVersion
 
 repositories {
     mavenCentral()
@@ -25,6 +27,7 @@ def languages = ["DE", "EN"]
 application {
     mainClass.set("org.isaqb.asciidoc.Main")
     applicationDefaultJvmArgs = [
+        """-DprojectVersion=${project.version}""",
         """-DcurriculumFileName=${curriculumFileName}""",
         """-DversionDate=${versionDate}""",
         """-Dlanguages=${languages.join(',')}"""]

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.asciidoctor:asciidoctorj:2.5.8")
+    implementation("org.asciidoctor:asciidoctorj:2.5.10")
     implementation("org.asciidoctor:asciidoctorj-pdf:2.3.7")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,9 @@ application {
         """-DprojectVersion=${project.version}""",
         """-DcurriculumFileName=${curriculumFileName}""",
         """-DversionDate=${versionDate}""",
-        """-Dlanguages=${languages.join(',')}"""]
+        """-Dlanguages=${languages.join(',')}""",
+        """--add-opens""", """java.base/sun.nio.ch=ALL-UNNAMED""",
+        """--add-opens""", """java.base/java.io=ALL-UNNAMED"""]
 }
 
 apply from: 'scripts/includeLearningObjectives.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -1,104 +1,40 @@
-import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import java.text.SimpleDateFormat
+import java.util.*
 
 plugins {
-    id "org.asciidoctor.jvm.base" version "3.3.2"
-    id "org.asciidoctor.jvm.convert" version "3.3.2"
-    id "org.asciidoctor.jvm.pdf" version "3.3.2"
+    id "java"
+    id "application"
 }
+
+def group = "org.isaqb"
+def version = "1.0-SNAPSHOT"
+
 repositories {
     mavenCentral()
 }
 
-asciidoctorj {
-    version = '2.5.3'
+dependencies {
+    implementation("org.asciidoctor:asciidoctorj:2.5.8")
+    implementation("org.asciidoctor:asciidoctorj-pdf:2.3.7")
 }
 
-ext {
-    today = new Date()
-    versionDate = new SimpleDateFormat("yyyyMMdd").format(today)
+def curriculumFileName = "curriculum-template"
+def versionDate = new SimpleDateFormat("yyyyMMdd").format(new Date())
+def languages = ["DE", "EN"]
 
-    releaseVersion = System.getenv("RELEASE_VERSION")
-    localVersion = "LocalBuild"
-    project.version = releaseVersion == null ? localVersion : releaseVersion;
-
-    curriculumFileName = "curriculum-template"
-    addSuffixToCurriculum = { suffix ->
-        for (extension in ["html", "pdf"]) {
-            File source = new File("${buildDir}/${curriculumFileName}.${extension}")
-            File target = new File("${buildDir}/${curriculumFileName}${suffix}.${extension}")
-
-            source.renameTo(target)
-        }
-    }
-}
-
-
-
-
-class RenderCurriculumTask extends AsciidoctorTask {
-    @Inject
-    RenderCurriculumTask(WorkerExecutor we, String curriculumFileName, String versionDate, String language) {
-        super(we)
-
-        forkOptions {
-            jvmArgs "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED"
-        }
-
-
-        sourceDir = new File("./docs/")
-        baseDir = new File ("./docs/")
-        sources {
-            include "index.adoc"
-            include "${curriculumFileName}.adoc"
-        }
-        outputDir = new File("./build/")
-        outputOptions {
-            separateOutputDirs = false
-            backends 'pdf', 'html5'
-        }
-
-        def fileVersion = project.version.trim() + "-" + language
-
-        attributes = [
-                'icons'             : 'font',
-                'version-label'     : '',
-                'revnumber'         : fileVersion,
-                'revdate'           : versionDate,
-                'document-version'  : fileVersion + "-" + versionDate,
-                'currentDate'       : versionDate,
-                'language'          : language,
-                'curriculumFileName': curriculumFileName,
-                'debug_adoc'        : false,
-                'pdf-stylesdir'     : '../pdf-theme/themes',
-                'pdf-fontsdir'      : '../pdf-theme/fonts',
-                'pdf-style'         : 'isaqb',
-                'stylesheet'        : '../html-theme/adoc-github.css',
-                'stylesheet-dir'    : '../html-theme'
-        ]
-    }
-}
-
-task buildDocs {
-    group 'Documentation'
-    description 'Grouping task for generating all languages in several formats'
-    dependsOn "includeLearningObjectives", "renderDE", "renderEN"
-}
-
-task renderDE(type: RenderCurriculumTask,
-        constructorArgs: [curriculumFileName, versionDate, "DE"]) {
-    doLast {
-        addSuffixToCurriculum("-de")
-    }
-}
-
-task renderEN(type: RenderCurriculumTask,
-        constructorArgs: [curriculumFileName, versionDate, "EN"]) {
-    doLast {
-        addSuffixToCurriculum("-en")
-    }
+application {
+    mainClass.set("org.isaqb.asciidoc.Main")
+    applicationDefaultJvmArgs = [
+        """-DcurriculumFileName=${curriculumFileName}""",
+        """-DversionDate=${versionDate}""",
+        """-Dlanguages=${languages.join(',')}"""]
 }
 
 apply from: 'scripts/includeLearningObjectives.gradle'
+
+task buildDocs {
+    description 'Grouping task for generating all languages in several formats'
+    dependsOn "includeLearningObjectives", "run"
+}
 
 defaultTasks "buildDocs"

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,10 @@ application {
 
 apply from: 'scripts/includeLearningObjectives.gradle'
 
-task buildDocs {
-    description 'Grouping task for generating all languages in several formats'
+task buildDocs (
+    description: 'Grouping task for generating all languages in several formats',
+    group: 'documentation'
+) {
     dependsOn "includeLearningObjectives", "run"
 }
 

--- a/src/main/java/org/isaqb/asciidoc/Main.java
+++ b/src/main/java/org/isaqb/asciidoc/Main.java
@@ -108,9 +108,9 @@ public class Main {
             put("language"          , language);
             put("curriculumFileName", curriculumFileName);
             put("debug_adoc"        , false);
-            put("pdf-stylesdir"     , "../pdf-theme/themes");
+            put("pdf-themesdir"     , "../pdf-theme/themes");
             put("pdf-fontsdir"      , "../pdf-theme/fonts");
-            put("pdf-style"         , "isaqb");
+            put("pdf-theme"         , "isaqb");
             put("stylesheet"        , "../html-theme/adoc-github.css");
             put("stylesheet-dir"    , "../html-theme");
             put("allow-uri-read"    , true);

--- a/src/main/java/org/isaqb/asciidoc/Main.java
+++ b/src/main/java/org/isaqb/asciidoc/Main.java
@@ -122,6 +122,7 @@ public class Main {
             put("pdf-theme"         , "isaqb");
             put("stylesheet"        , "../html-theme/adoc-github.css");
             put("stylesheet-dir"    , "../html-theme");
+            put("data-uri"          , true);
             put("allow-uri-read"    , true);
         }};
 

--- a/src/main/java/org/isaqb/asciidoc/Main.java
+++ b/src/main/java/org/isaqb/asciidoc/Main.java
@@ -1,0 +1,143 @@
+package org.isaqb.asciidoc;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.asciidoctor.SafeMode;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.asciidoctor.Asciidoctor.Factory.create;
+
+public class Main {
+
+    private static final String CURRICULUM_FILE_NAME = "curriculumFileName";
+    private static final String VERSION_DATE = "versionDate";
+    private static final String LANGUAGES = "languages";
+    private static final String[] FORMATS = {"html", "pdf"};
+
+    private static final String LANGUAGE_SEPERATOR = ",";
+
+    private static final String PROJECT_VERSION = "?";
+    private static final String SOURCE_DIR = "./docs/";
+    private static final String BASE_DIR = SOURCE_DIR;
+    private static final String OUTPUT_DIR = "./build/";
+
+    private static final String ADOC = "adoc";
+    private static final String HTML = "html";
+    private static final String PDF = "pdf";
+
+    public static void main(final String[] args) {
+        Objects.requireNonNull(System.getProperty(CURRICULUM_FILE_NAME));
+        Objects.requireNonNull(System.getProperty(VERSION_DATE));
+        Objects.requireNonNull(System.getProperty(LANGUAGES));
+
+        final String curriculumFileName = System.getProperty(CURRICULUM_FILE_NAME);
+        final String versionDate = System.getProperty(VERSION_DATE);
+        final String[] languages = System.getProperty(LANGUAGES).split(LANGUAGE_SEPERATOR);
+
+        System.out.printf("Source Directory: %s\n", new File(SOURCE_DIR).getAbsolutePath());
+        System.out.printf("Base Directory: %s\n", new File(BASE_DIR).getAbsolutePath());
+        System.out.printf("Output Directory: %s\n", new File(OUTPUT_DIR).getAbsolutePath());
+        System.out.printf("Property CURRICULUM_FILE_NAME: %s\n", curriculumFileName);
+        System.out.printf("Property VERSION_DATE: %s\n", versionDate);
+        System.out.printf("Property LANGUAGES: %s\n", String.join(LANGUAGE_SEPERATOR, languages));
+
+        Stream.of(languages).forEach(language -> convert(
+                curriculumFileName,
+                versionDate,
+                language));
+    }
+
+    private static void convert(
+            final String curriculumFileName,
+            final String versionDate,
+            final String language) {
+        Stream.of(FORMATS).forEach(format -> convert(
+                curriculumFileName,
+                versionDate,
+                language,
+                format));
+    }
+
+    private static void convert(
+            final String curriculumFileName,
+            final String versionDate,
+            final String language,
+            final String format) {
+        try (final Asciidoctor asciidoctor = create()) {
+            final List<String> fileNames = Arrays.asList(curriculumFileName, "index");
+            final Attributes attributes = toAttributes(
+                    curriculumFileName,
+                    versionDate,
+                    language);
+            asciidoctor.convertDirectory(
+                    fileNames.stream()
+                            .map(it -> "%s%s.%s".formatted(SOURCE_DIR, it, ADOC))
+                            .map(File::new)
+                            .toList(),
+                    Options.builder()
+                            .baseDir(new File(BASE_DIR))
+                            .backend(toBackend(format))
+                            .mkDirs(true)
+                            .attributes(attributes)
+                            .standalone(true)
+                            .toDir(new File(OUTPUT_DIR))
+                            .safe(SafeMode.UNSAFE)
+                            .build());
+            renameResultAccordingToLanguage(curriculumFileName, format, language);
+        }
+    }
+
+    private static Attributes toAttributes(
+            final String curriculumFileName,
+            final String versionDate,
+            final String language) {
+        final String fileVersion = "%s - %s".formatted(PROJECT_VERSION, language);
+        final String documentVersion = "%s-%s".formatted(fileVersion, versionDate);
+
+        final Map<String, Object> attributes = new HashMap<>() {{
+            put("icons"             , "font");
+            put("version-label"     , "");
+            put("revnumber"         , fileVersion);
+            put("revdate"           , versionDate);
+            put("document-version"  , documentVersion);
+            put("currentDate"       , versionDate);
+            put("language"          , language);
+            put("curriculumFileName", curriculumFileName);
+            put("debug_adoc"        , false);
+            put("pdf-stylesdir"     , "../pdf-theme/themes");
+            put("pdf-fontsdir"      , "../pdf-theme/fonts");
+            put("pdf-style"         , "isaqb");
+            put("stylesheet"        , "../html-theme/adoc-github.css");
+            put("stylesheet-dir"    , "../html-theme");
+            put("allow-uri-read"    , true);
+        }};
+
+        return Attributes.builder().attributes(attributes).build();
+    }
+
+    private static String toBackend(final String format) {
+        return switch (format) {
+            case HTML -> "html5";
+            case PDF -> PDF;
+            default -> throw new IllegalArgumentException("Unknown target format %s".formatted(format));
+        };
+    }
+
+    private static void renameResultAccordingToLanguage(
+            final String fileName,
+            final String format,
+            final String language) {
+        final File original = new File("%s%s.%s".formatted(OUTPUT_DIR, fileName, format));
+        final File renamed = new File("%s%s-%s.%s".formatted(OUTPUT_DIR, fileName, language.toLowerCase(), format));
+        if (!original.exists()) {
+            System.err.printf("Failed to rename result file %s as it does not exist", original.getAbsolutePath());
+        } else if (!original.renameTo(renamed)) {
+            System.err.printf("Failed to rename result file %s to %s", original.getName(), renamed.getName());
+        }
+        original.deleteOnExit();
+    }
+}

--- a/src/main/java/org/isaqb/asciidoc/Main.java
+++ b/src/main/java/org/isaqb/asciidoc/Main.java
@@ -13,6 +13,7 @@ import static org.asciidoctor.Asciidoctor.Factory.create;
 
 public class Main {
 
+    private static final String PROJECT_VERSION = "projectVersion";
     private static final String CURRICULUM_FILE_NAME = "curriculumFileName";
     private static final String VERSION_DATE = "versionDate";
     private static final String LANGUAGES = "languages";
@@ -20,7 +21,6 @@ public class Main {
 
     private static final String LANGUAGE_SEPERATOR = ",";
 
-    private static final String PROJECT_VERSION = "?";
     private static final String SOURCE_DIR = "./docs/";
     private static final String BASE_DIR = SOURCE_DIR;
     private static final String OUTPUT_DIR = "./build/";
@@ -30,10 +30,12 @@ public class Main {
     private static final String PDF = "pdf";
 
     public static void main(final String[] args) {
+        Objects.requireNonNull(System.getProperty(PROJECT_VERSION));
         Objects.requireNonNull(System.getProperty(CURRICULUM_FILE_NAME));
         Objects.requireNonNull(System.getProperty(VERSION_DATE));
         Objects.requireNonNull(System.getProperty(LANGUAGES));
 
+        final String projectVersion = System.getProperty(PROJECT_VERSION);
         final String curriculumFileName = System.getProperty(CURRICULUM_FILE_NAME);
         final String versionDate = System.getProperty(VERSION_DATE);
         final String[] languages = System.getProperty(LANGUAGES).split(LANGUAGE_SEPERATOR);
@@ -41,21 +43,25 @@ public class Main {
         System.out.printf("Source Directory: %s\n", new File(SOURCE_DIR).getAbsolutePath());
         System.out.printf("Base Directory: %s\n", new File(BASE_DIR).getAbsolutePath());
         System.out.printf("Output Directory: %s\n", new File(OUTPUT_DIR).getAbsolutePath());
+        System.out.printf("Property PROJECT_VERSION: %s\n", projectVersion);
         System.out.printf("Property CURRICULUM_FILE_NAME: %s\n", curriculumFileName);
         System.out.printf("Property VERSION_DATE: %s\n", versionDate);
         System.out.printf("Property LANGUAGES: %s\n", String.join(LANGUAGE_SEPERATOR, languages));
 
         Stream.of(languages).forEach(language -> convert(
+                projectVersion,
                 curriculumFileName,
                 versionDate,
                 language));
     }
 
     private static void convert(
+            final String projectVersion,
             final String curriculumFileName,
             final String versionDate,
             final String language) {
         Stream.of(FORMATS).forEach(format -> convert(
+                projectVersion,
                 curriculumFileName,
                 versionDate,
                 language,
@@ -63,6 +69,7 @@ public class Main {
     }
 
     private static void convert(
+            final String projectVersion,
             final String curriculumFileName,
             final String versionDate,
             final String language,
@@ -70,6 +77,7 @@ public class Main {
         try (final Asciidoctor asciidoctor = create()) {
             final List<String> fileNames = Arrays.asList(curriculumFileName, "index");
             final Attributes attributes = toAttributes(
+                    projectVersion,
                     curriculumFileName,
                     versionDate,
                     language);
@@ -92,10 +100,11 @@ public class Main {
     }
 
     private static Attributes toAttributes(
+            final String projectVersion,
             final String curriculumFileName,
             final String versionDate,
             final String language) {
-        final String fileVersion = "%s - %s".formatted(PROJECT_VERSION, language);
+        final String fileVersion = "%s - %s".formatted(projectVersion, language);
         final String documentVersion = "%s-%s".formatted(fileVersion, versionDate);
 
         final Map<String, Object> attributes = new HashMap<>() {{


### PR DESCRIPTION
Ersetzt das Gradle Plugin für AsciidoctorJ durch die Einbindung von AsciidoctorJ selbst, welches von einem minimalen Java Programm aufgerufen wird. Dadurch kann jederzeit auf die aktuellste Version von AsciidoctorJ migriert werden.